### PR TITLE
Use req.prerender.url instead of req.url

### DIFF
--- a/lib/mongoCache.js
+++ b/lib/mongoCache.js
@@ -35,7 +35,7 @@ module.exports = {
     },
 
     afterPhantomRequest: function(req, res, next) {
-        this.cache.set(req.url, req.prerender.documentHTML);
+        this.cache.set(req.prerender.url, req.prerender.documentHTML);
         next();
     }
 };


### PR DESCRIPTION
This is because prerender does some extra wrangling on the url, removing _escaped_fragment_ and so on