### PR TITLE
Remove cache-manager dependency

### DIFF
--- a/lib/mongoCache.js
+++ b/lib/mongoCache.js
@@ -11,13 +11,9 @@ MongoClient.connect(mongoUri, function(err, db) {
     database = db;
 });
 
-var cache_manager = require('cache-manager');
-
 module.exports = {
     init: function() {
-        this.cache = cache_manager.caching({
-            store: mongo_cache
-        });
+        this.cache = mongo_cache;
     },
 
     beforePhantomRequest: function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/lammertw/prerender-mongodb-cache",
   "dependencies": {
-    "mongodb": "~2.1.0",
-    "cache-manager": "0.2.0"
+    "mongodb": "~2.1.0"
   }
 }


### PR DESCRIPTION
Hi, @lammertw. I was reviewing this plugin and found it may not be providing the tiered priority caching benefits via `cache-manager` that you expect. You will find in the `cache-manager` source it is simply proxying the interface of your custom store (i.e. `mongo_cache`) without providing any in memory priority caching benefits (https://github.com/BryanDonovan/node-cache-manager/blob/master/lib/caching.js#L130). To leverage a tiered cache with `cache-manager` caching would need to be configured via its [Multi Store](https://github.com/BryanDonovan/node-cache-manager#multi-store) api. This pull request removes the dependency of this plugin on `cache-manager` as it is not providing its intended value. 

Please let me know if I am wrong or my understanding of the `cache-manager` source to be incorrect.
